### PR TITLE
sound: codecs: Introduce PDesireAudio 1.0 for WCD9335

### DIFF
--- a/sound/soc/codecs/wcd9335.c
+++ b/sound/soc/codecs/wcd9335.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2016, The Linux Foundation. All rights reserved.
- *
+ * Copyright (C) 2017, Tristan Marsell. All rights reserved.
+ * 
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
  * only version 2 as published by the Free Software Foundation.
@@ -54,7 +55,8 @@
 
 #define WCD9335_RATES_MASK (SNDRV_PCM_RATE_8000 | SNDRV_PCM_RATE_16000 |\
 			    SNDRV_PCM_RATE_32000 | SNDRV_PCM_RATE_48000 |\
-			    SNDRV_PCM_RATE_96000 | SNDRV_PCM_RATE_192000)
+			    SNDRV_PCM_RATE_96000 | SNDRV_PCM_RATE_192000 |\
+			    SNDRV_PCM_RATE_384000)
 /* Fractional Rates */
 #define WCD9335_FRAC_RATES_MASK (SNDRV_PCM_RATE_44100)
 
@@ -167,6 +169,16 @@ enum tasha_sido_voltage {
 };
 
 static enum codec_variant codec_ver;
+
+static int pdesireaudio_uhqa_mode = 1;
+module_param(pdesireaudio_uhqa_mode, int,
+		S_IRUGO | S_IWUSR | S_IWGRP);
+MODULE_PARM_DESC(pdesireaudio_uhqa_mode, "enable/disable PDesireAudio UHQA Mode");
+
+static int pdesireaudio_class_ab_mode = 1;
+module_param(pdesireaudio_class_ab_mode, int,
+		S_IRUGO | S_IWUSR | S_IWGRP);
+MODULE_PARM_DESC(pdesireaudio_class_ab_mode, "enable/disable PDesireAudio Class AB Mode");
 
 static int dig_core_collapse_enable = 1;
 module_param(dig_core_collapse_enable, int,
@@ -444,6 +456,7 @@ static struct interp_sample_rate int_mix_sample_rate_val[] = {
 	{48000, 0x4},	/* 48K */
 	{96000, 0x5},	/* 96K */
 	{192000, 0x6},	/* 192K */
+	{384000, 0x7},	/* 384K */
 };
 
 static const struct wcd9xxx_ch tasha_rx_chs[TASHA_RX_MAX] = {
@@ -3732,7 +3745,11 @@ static void tasha_codec_hph_post_pa_config(struct tasha_priv *tasha,
 			scale_val = 0x3;
 			break;
 		case CLS_H_LOHIFI:
-			scale_val = 0x1;
+			// Force HIFI 
+			if (!pdesireaudio_uhqa_mode)
+				scale_val = 0x1;
+			else
+				scale_val = 0x3;
 			break;
 		}
 		if (tasha->anc_func) {
@@ -4210,12 +4227,19 @@ static void tasha_codec_hph_mode_config(struct snd_soc_codec *codec,
 	if (!TASHA_IS_2_0(tasha->wcd9xxx->version))
 		return;
 
+	//Force HIFI Mode
 	switch (mode) {
 	case CLS_H_LP:
-		tasha_codec_hph_lp_config(codec, event);
+		if (!pdesireaudio_uhqa_mode)
+			tasha_codec_hph_lp_config(codec, event);
+		else 
+		tasha_codec_hph_hifi_config(codec, event);
 		break;
 	case CLS_H_LOHIFI:
-		tasha_codec_hph_lohifi_config(codec, event);
+		if (!pdesireaudio_uhqa_mode)
+			tasha_codec_hph_lohifi_config(codec, event);
+		else
+			tasha_codec_hph_hifi_config(codec, event);
 		break;
 	case CLS_H_HIFI:
 		tasha_codec_hph_hifi_config(codec, event);
@@ -4254,11 +4278,18 @@ static int tasha_codec_hphr_dac_event(struct snd_soc_dapm_widget *w,
 					__func__, hph_mode);
 			return -EINVAL;
 		}
-		wcd_clsh_fsm(codec, &tasha->clsh_d,
-			     WCD_CLSH_EVENT_PRE_DAC,
-			     WCD_CLSH_STATE_HPHR,
-			     ((hph_mode == CLS_H_LOHIFI) ?
-			       CLS_H_HIFI : hph_mode));
+		if (!pdesireaudio_class_ab_mode) {
+			wcd_clsh_fsm(codec, &tasha->clsh_d,
+					 WCD_CLSH_EVENT_PRE_DAC,
+					 WCD_CLSH_STATE_HPHR,
+					 ((hph_mode == CLS_H_LOHIFI) ?
+					   CLS_H_HIFI : hph_mode));
+		} else {
+			wcd_clsh_fsm(codec, &tasha->clsh_d,
+					 WCD_CLSH_EVENT_PRE_DAC,
+					 WCD_CLSH_STATE_HPHR,
+					 CLS_AB);
+		}
 
 		tasha_codec_hph_mode_config(codec, event, hph_mode);
 
@@ -4290,12 +4321,18 @@ static int tasha_codec_hphr_dac_event(struct snd_soc_dapm_widget *w,
 		if (!(wcd_clsh_get_clsh_state(&tasha->clsh_d) &
 		     WCD_CLSH_STATE_HPHL))
 			tasha_codec_hph_mode_config(codec, event, hph_mode);
-
-		wcd_clsh_fsm(codec, &tasha->clsh_d,
-			     WCD_CLSH_EVENT_POST_PA,
-			     WCD_CLSH_STATE_HPHR,
-			     ((hph_mode == CLS_H_LOHIFI) ?
-			       CLS_H_HIFI : hph_mode));
+		if (!pdesireaudio_class_ab_mode) {
+			wcd_clsh_fsm(codec, &tasha->clsh_d,
+					 WCD_CLSH_EVENT_POST_PA,
+					 WCD_CLSH_STATE_HPHR,
+					 ((hph_mode == CLS_H_LOHIFI) ?
+					   CLS_H_HIFI : hph_mode));
+		} else {
+			wcd_clsh_fsm(codec, &tasha->clsh_d,
+					 WCD_CLSH_EVENT_POST_PA,
+					 WCD_CLSH_STATE_HPHR,
+					 CLS_AB);
+		}
 		break;
 	};
 
@@ -4334,11 +4371,19 @@ static int tasha_codec_hphl_dac_event(struct snd_soc_dapm_widget *w,
 					__func__, hph_mode);
 			return -EINVAL;
 		}
-		wcd_clsh_fsm(codec, &tasha->clsh_d,
-			     WCD_CLSH_EVENT_PRE_DAC,
-			     WCD_CLSH_STATE_HPHL,
-			     ((hph_mode == CLS_H_LOHIFI) ?
-			       CLS_H_HIFI : hph_mode));
+		
+		if (!pdesireaudio_class_ab_mode) {
+			wcd_clsh_fsm(codec, &tasha->clsh_d,
+					 WCD_CLSH_EVENT_PRE_DAC,
+					 WCD_CLSH_STATE_HPHL,
+					 ((hph_mode == CLS_H_LOHIFI) ?
+					   CLS_H_HIFI : hph_mode));
+		} else {
+			wcd_clsh_fsm(codec, &tasha->clsh_d,
+					 WCD_CLSH_EVENT_PRE_DAC,
+					 WCD_CLSH_STATE_HPHL,
+					 CLS_AB);
+		}
 
 		tasha_codec_hph_mode_config(codec, event, hph_mode);
 
@@ -4351,7 +4396,7 @@ static int tasha_codec_hphl_dac_event(struct snd_soc_dapm_widget *w,
 		if (!ret) {
 			wcd_clsh_imped_config(codec, impedl, false);
 			set_bit(CLASSH_CONFIG, &tasha->status_mask);
-		} else
+		} else 
 			dev_dbg(codec->dev, "%s: Failed to get mbhc impedance %d\n",
 						__func__, ret);
 
@@ -4380,11 +4425,18 @@ static int tasha_codec_hphl_dac_event(struct snd_soc_dapm_widget *w,
 		if (!(wcd_clsh_get_clsh_state(&tasha->clsh_d) &
 		     WCD_CLSH_STATE_HPHR))
 			tasha_codec_hph_mode_config(codec, event, hph_mode);
-		wcd_clsh_fsm(codec, &tasha->clsh_d,
+		if (!pdesireaudio_class_ab_mode) {
+			wcd_clsh_fsm(codec, &tasha->clsh_d,
+					 WCD_CLSH_EVENT_POST_PA,
+					 WCD_CLSH_STATE_HPHL,
+					 ((hph_mode == CLS_H_LOHIFI) ?
+					   CLS_H_HIFI : hph_mode));
+		} else {
+			wcd_clsh_fsm(codec, &tasha->clsh_d,
 			     WCD_CLSH_EVENT_POST_PA,
 			     WCD_CLSH_STATE_HPHL,
-			     ((hph_mode == CLS_H_LOHIFI) ?
-			       CLS_H_HIFI : hph_mode));
+			     CLS_AB);
+		}
 
 		if (test_bit(CLASSH_CONFIG, &tasha->status_mask)) {
 			wcd_clsh_imped_config(codec, impedl, true);
@@ -4456,6 +4508,7 @@ static int tasha_codec_ear_dac_event(struct snd_soc_dapm_widget *w,
 	struct snd_soc_codec *codec = w->codec;
 	struct tasha_priv *tasha = snd_soc_codec_get_drvdata(codec);
 	int ret = 0;
+	int hph_mode = tasha->hph_mode;
 
 	dev_dbg(codec->dev, "%s %s %d\n", __func__, w->name, event);
 
@@ -4463,11 +4516,25 @@ static int tasha_codec_ear_dac_event(struct snd_soc_dapm_widget *w,
 	case SND_SOC_DAPM_PRE_PMU:
 		if (tasha->anc_func)
 			ret = tasha_codec_enable_anc(w, kcontrol, event);
-
-		wcd_clsh_fsm(codec, &tasha->clsh_d,
+		if (!pdesireaudio_class_ab_mode) {
+			if (pdesireaudio_uhqa_mode) {
+			wcd_clsh_fsm(codec, &tasha->clsh_d,
 			     WCD_CLSH_EVENT_PRE_DAC,
 			     WCD_CLSH_STATE_EAR,
-			     CLS_H_NORMAL);
+			     ((hph_mode == CLS_H_LOHIFI) ?
+					   CLS_H_HIFI : hph_mode));
+			} else {
+				wcd_clsh_fsm(codec, &tasha->clsh_d,
+					WCD_CLSH_EVENT_PRE_DAC,
+					WCD_CLSH_STATE_EAR,
+					CLS_H_NORMAL);
+			}
+		} else {
+			wcd_clsh_fsm(codec, &tasha->clsh_d,
+			     WCD_CLSH_EVENT_PRE_DAC,
+			     WCD_CLSH_STATE_EAR,
+			     CLS_AB);
+		}
 		if (tasha->anc_func)
 			snd_soc_update_bits(codec,
 				WCD9335_CDC_RX0_RX_PATH_CFG0, 0x10, 0x10);
@@ -4478,10 +4545,25 @@ static int tasha_codec_ear_dac_event(struct snd_soc_dapm_widget *w,
 	case SND_SOC_DAPM_PRE_PMD:
 		break;
 	case SND_SOC_DAPM_POST_PMD:
-		wcd_clsh_fsm(codec, &tasha->clsh_d,
+		if (!pdesireaudio_class_ab_mode) {
+			if (!pdesireaudio_uhqa_mode) {
+				wcd_clsh_fsm(codec, &tasha->clsh_d,
+						 WCD_CLSH_EVENT_POST_PA,
+						 WCD_CLSH_STATE_EAR,
+						 CLS_H_NORMAL);
+			} else {
+				wcd_clsh_fsm(codec, &tasha->clsh_d,
+						 WCD_CLSH_EVENT_POST_PA,
+						 WCD_CLSH_STATE_EAR,
+						 ((hph_mode == CLS_H_LOHIFI) ?
+								CLS_H_HIFI : hph_mode));
+			}
+		} else {
+			wcd_clsh_fsm(codec, &tasha->clsh_d,
 			     WCD_CLSH_EVENT_POST_PA,
 			     WCD_CLSH_STATE_EAR,
-			     CLS_H_NORMAL);
+			     CLS_AB);
+		}
 		break;
 	};
 
@@ -7571,13 +7653,13 @@ static int tasha_mad_input_put(struct snd_kcontrol *kcontrol,
 	char *mad_input;
 
 	tasha_mad_input = ucontrol->value.integer.value[0];
-
+	
 	if (tasha_mad_input >= ARRAY_SIZE(tasha_conn_mad_text)) {
-		dev_err(codec->dev,
-			"%s: tasha_mad_input = %d out of bounds\n",
-			__func__, tasha_mad_input);
-		return -EINVAL;
-	}
+ 		dev_err(codec->dev,
+ 			"%s: tasha_mad_input = %d out of bounds\n",
+ 			__func__, tasha_mad_input);
+ 		return -EINVAL;
+ 	}
 
 	if (!strcmp(tasha_conn_mad_text[tasha_mad_input], "NOTUSED1") ||
 	    !strcmp(tasha_conn_mad_text[tasha_mad_input], "NOTUSED2") ||
@@ -11161,6 +11243,10 @@ static int tasha_hw_params(struct snd_pcm_substream *substream,
 			tasha->dai[dai->id].bit_width = 24;
 			i2s_bit_mode = 0x00;
 			break;
+		case 32:
+			tasha->dai[dai->id].bit_width = 32;
+			i2s_bit_mode = 0x00;
+			break;
 		default:
 			return -EINVAL;
 		}
@@ -11185,6 +11271,9 @@ static int tasha_hw_params(struct snd_pcm_substream *substream,
 			case 192000:
 				rx_fs_rate = 5;
 				break;
+			case 384000:
+				rx_fs_rate = 6;
+				break;
 			default:
 				dev_err(tasha->dev,
 				"%s: Invalid RX sample rate: %d\n",
@@ -11207,6 +11296,7 @@ static int tasha_hw_params(struct snd_pcm_substream *substream,
 		case 16000:
 			tx_fs_rate = 1;
 			break;
+		// Something went here definitly wrong
 		case 32000:
 			tx_fs_rate = 3;
 			break;
@@ -13880,5 +13970,5 @@ static struct platform_driver tasha_codec_driver = {
 
 module_platform_driver(tasha_codec_driver);
 
-MODULE_DESCRIPTION("Tasha Codec driver");
+MODULE_DESCRIPTION("PDesireAudio Tasha Codec driver");
 MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
Finally introduce PDesireAudio for WCD9335 devices

Features:

Forcing HiFi or / and Class_AB mode

Forgot to tell on Commit Description:
It also fixes some things on driver

Signed-off-by: Tristan Marsell <tristan.marsell@t-online.de>